### PR TITLE
[fix] Added PHP7.4 Support for excel export 2

### DIFF
--- a/lib/PHPExcel/Calculation/Functions.php
+++ b/lib/PHPExcel/Calculation/Functions.php
@@ -308,7 +308,7 @@ class PHPExcel_Calculation_Functions {
 
 	public static function _ifCondition($condition) {
 		$condition	= PHPExcel_Calculation_Functions::flattenSingleValue($condition);
-		if (!in_array($condition{0},array('>', '<', '='))) {
+		if (!in_array($condition[0],array('>', '<', '='))) {
 			if (!is_numeric($condition)) { $condition = PHPExcel_Calculation::_wrapResult(strtoupper($condition)); }
 			return '='.$condition;
 		} else {
@@ -514,13 +514,11 @@ class PHPExcel_Calculation_Functions {
 			case 'float'	:
 			case 'integer'	:
 				return $value;
-				break;
 			case 'boolean'	:
 				return (integer) $value;
-				break;
 			case 'string'	:
 				//	Errors
-				if ((strlen($value) > 0) && ($value{0} == '#')) {
+				if ((strlen($value) > 0) && ($value[0] == '#')) {
 					return $value;
 				}
 				break;
@@ -567,7 +565,6 @@ class PHPExcel_Calculation_Functions {
 				return 4;
 		} elseif(is_array($value)) {
 				return 64;
-				break;
 		} elseif(is_string($value)) {
 			//	Errors
 			if ((strlen($value) > 0) && ($value{0} == '#')) {


### PR DESCRIPTION
1. Fatal error: 'break' not in the 'loop' or 'switch' context in
 - FIX

2. Array and string offset access syntax with curly braces is deprecated in
 - FIX

Tested on php7.4